### PR TITLE
fix: validate regex capture lengths before slicing in appendCheck

### DIFF
--- a/playlist/playlist.go
+++ b/playlist/playlist.go
@@ -126,16 +126,25 @@ func appendCheck(url string) (appended string, err error) {
 		return url, fmt.Errorf("uid not found")
 	}
 	uidMatch := uidMatches[1]
+	if len(uidMatch) < 6 {
+		return url, fmt.Errorf("uid too short")
+	}
 	expiresMatches := RegexExpires.FindStringSubmatch(url)
 	if len(expiresMatches) < 2 {
 		return url, fmt.Errorf("uid not found")
 	}
 	expiresMatch := expiresMatches[1]
+	if len(expiresMatch) < 4 {
+		return url, fmt.Errorf("expires too short")
+	}
 	requestMatches := RegexRequest.FindStringSubmatch(url)
 	if len(requestMatches) < 2 {
 		return url, fmt.Errorf("uid not found")
 	}
 	requestMatch := requestMatches[1]
+	if len(requestMatch) < 4 {
+		return url, fmt.Errorf("request_id too short")
+	}
 	expiredSeg := reverseString(reverseString(expiresMatch)[0:4])
 	appended = fmt.Sprintf("%s&check=%s%s%s", url, requestMatch[0:4], uidMatch[2:6], expiredSeg)
 	return

--- a/playlist/playlist_test.go
+++ b/playlist/playlist_test.go
@@ -1,0 +1,38 @@
+package playlist
+
+import "testing"
+
+// A uid value shorter than 6 chars used to panic with "slice bounds out of
+// range [:6]" instead of falling back to returning the original url like
+// the other malformed-parameter cases already do.
+func TestAppendCheckShortUidDoesNotPanic(t *testing.T) {
+	url := "https://example.com/frag.ts?uid=abc&expires=1234567890&request_id=abcdef"
+	if _, err := appendCheck(url); err == nil {
+		t.Errorf("expected an error for a short uid, got nil")
+	}
+}
+
+func TestAppendCheckShortRequestIdDoesNotPanic(t *testing.T) {
+	url := "https://example.com/frag.ts?uid=abcdefghi&expires=1234567890&request_id=ab"
+	if _, err := appendCheck(url); err == nil {
+		t.Errorf("expected an error for a short request_id, got nil")
+	}
+}
+
+func TestAppendCheckShortExpiresDoesNotPanic(t *testing.T) {
+	url := "https://example.com/frag.ts?uid=abcdefghi&expires=12&request_id=abcdef"
+	if _, err := appendCheck(url); err == nil {
+		t.Errorf("expected an error for a short expires, got nil")
+	}
+}
+
+func TestAppendCheckWellFormed(t *testing.T) {
+	url := "https://example.com/frag.ts?uid=abcdefghi&expires=1234567890&request_id=abcdef"
+	appended, err := appendCheck(url)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if appended == url {
+		t.Errorf("expected the url to have a check param appended, got %q", appended)
+	}
+}


### PR DESCRIPTION
appendCheck slices uidMatch[2:6], requestMatch[0:4] and expiresMatch[...][0:4] without checking their length first, so a short uid/expires/request_id capture panics with a slice bounds error and crashes the whole download instead of just falling back to the unmodified url like the other malformed-parameter cases already do. Added the missing length checks and a couple of tests.